### PR TITLE
Hansenmc code coverage

### DIFF
--- a/src/main/ml-modules/root/test/test-coverage.xqy
+++ b/src/main/ml-modules/root/test/test-coverage.xqy
@@ -74,7 +74,6 @@ declare private function cover:_task-cancel-safe(
     if (fn:empty(dbg:wait($id, 10))) then
       fn:error(xs:QName("FAILED-TO-CANCEL"), "unable to cancel a debugging request")
     else ()
-    (: xdmp:request-cancel(xdmp:host(), xdmp:server("TaskServer"), $id) :)
   }
   catch ($ex) {
     if ($ex/error:code eq 'XDMP-NOREQUEST') then ()

--- a/src/test/ml-modules/root/test/suites/More Unit Tests/assert-true.xqy
+++ b/src/test/ml-modules/root/test/suites/More Unit Tests/assert-true.xqy
@@ -25,9 +25,6 @@ test:assert-true((fn:true(), fn:true())),
 test:assert-throws-error(xdmp:function(xs:QName("local:case1")), "ASSERT-TRUE-FAILED"),
 test:assert-throws-error(xdmp:function(xs:QName("local:case2")), "ASSERT-TRUE-FAILED"),
 
-(: Causing this one to fail on purpose :)
-test:assert-true(fn:false(), "test"),
-
 test:assert-true((fn:true(), fn:true()), "test"),
 test:assert-throws-error(xdmp:function(xs:QName("local:case3")), "ASSERT-TRUE-FAILED"),
 test:assert-throws-error(xdmp:function(xs:QName("local:case4")), "ASSERT-TRUE-FAILED")

--- a/src/test/ml-modules/root/test/suites/Unit Test Tests/assert-false.xqy
+++ b/src/test/ml-modules/root/test/suites/Unit Test Tests/assert-false.xqy
@@ -12,8 +12,5 @@ declare function local:case2()
 
 test:assert-false(fn:false()),
 
-(: Causing this one to fail on purpose :)
-test:assert-false((fn:true(), fn:false())),
-
 test:assert-throws-error(xdmp:function(xs:QName("local:case1")), "ASSERT-FALSE-FAILED"),
 test:assert-throws-error(xdmp:function(xs:QName("local:case2")), "ASSERT-FALSE-FAILED")


### PR DESCRIPTION
@hansenmc this PR against your code has the following changes:

- what I believe is an improvement to _task-cancel-safe -- using the dbg functions to detach and then wait for that request to conclude, instead of sending a cancel request and moving on
- _prepare-from-request, skip the find-the-lines process if the map already has a list for the target file
- ignore `DBG-MODULEDNE`, because that's really common. The debugger only finds modules that are used by the main module that was invoked
- dropped the fail-on-purpose tests. That functionality is covered by the `assert-throws-error` tests (I think these tests came over from the original Roxy)
- added some comments